### PR TITLE
Fix #8: Add basename to BrowserRouter and fix nested route paths

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -20,9 +20,9 @@ const App = () => {
       <main>
         <Routes>
           <Route path='/' element={<CatBreeds />} />
-          <Route path='/detail/:name' element={<DetailsBreed />} />
-          <Route path='/apidoc' element={<ApiDocumentation />} />
-          <Route path='/404' element={<PageNotFound />} />
+          <Route path='detail/:name' element={<DetailsBreed />} />
+          <Route path='apidoc' element={<ApiDocumentation />} />
+          <Route path='404' element={<PageNotFound />} />
         </Routes>
       </main>
       <footer>

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const store = configStore();
 ReactDOM.render(
   <React.StrictMode>
     <ErrorBoundary>
-      <BrowserRouter>
+      <BrowserRouter basename="/cats-guide">
         <Provider store={store}>
           <Routes>
             <Route path='/' element={<LandingPage />} />


### PR DESCRIPTION
## Summary
- Add `basename="/cats-guide"` to `<BrowserRouter>` in `src/index.js` to align with the `homepage` field in `package.json`
- Remove leading `/` from nested routes in `src/app/App.jsx` following react-router-dom v6 best practices

## Test plan
- [x] La app levanta sin pantalla en blanco en `http://localhost:3000/cats-guide`
- [x] No aparece el error `No routes matched location '/cats-guide'` en consola
- [ ] La navegación entre rutas (`/cats-guide/App/`, `/cats-guide/App/detail/:name`, `/cats-guide/App/apidoc`) funciona correctamente

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)