### PR TITLE
feat: persist daily cat in localStorage

### DIFF
--- a/src/app/LandingPage/LandingPage.jsx
+++ b/src/app/LandingPage/LandingPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import './LandingPage.css';
 import Spinner from '../Spinner/Spinner';
 import { Link } from 'react-router-dom';
-import { getRandomImage } from '../api/catBreedsActions';
+import { getDailyCat } from '../api/catBreedsActions';
 import { useDispatch, useSelector } from 'react-redux';
 
 const LandingPage = () => {
@@ -10,8 +10,8 @@ const LandingPage = () => {
   const cat = useSelector((state) => state.cats.randomCat);
 
   useEffect(() => {
-    dispatch(getRandomImage());
-  }, []);
+    dispatch(getDailyCat());
+  }, [dispatch]);
 
   return (
     <div className='root'>

--- a/src/app/api/catBreedsActions.js
+++ b/src/app/api/catBreedsActions.js
@@ -1,4 +1,3 @@
-import useFetch from '../../services/useFetch';
 import {
   asyncActionError,
   asyncActionFinish,
@@ -12,6 +11,48 @@ import {
 
 const baseUrl = 'https://api.thecatapi.com/v1/';
 const headers = { 'x-api-key': 'c2db22b7-52b8-4f16-82db-c0cbb4d39136' };
+const DAILY_CAT_CACHE_KEY = 'cats-guide:daily-cat';
+
+function getTodayDate() {
+  return new Date().toLocaleDateString('en-CA');
+}
+
+function readDailyCatCache() {
+  try {
+    const cachedValue = localStorage.getItem(DAILY_CAT_CACHE_KEY);
+
+    if (!cachedValue) {
+      return null;
+    }
+
+    const parsedCache = JSON.parse(cachedValue);
+    if (!parsedCache || typeof parsedCache !== 'object') {
+      return null;
+    }
+
+    if (!parsedCache.date || !parsedCache.cat) {
+      return null;
+    }
+
+    return parsedCache;
+  } catch (error) {
+    return null;
+  }
+}
+
+function writeDailyCatCache(cat) {
+  try {
+    localStorage.setItem(
+      DAILY_CAT_CACHE_KEY,
+      JSON.stringify({
+        date: getTodayDate(),
+        cat,
+      })
+    );
+  } catch (error) {
+    // Ignore storage failures and fall back to normal API behavior.
+  }
+}
 
 export function getCatsBreeds() {
   return async function (dispatch) {
@@ -29,13 +70,24 @@ export function getCatsBreeds() {
   };
 }
 
-export function getRandomImage() {
+export function getDailyCat() {
   return async function (dispatch) {
     dispatch(asyncActionStart());
+
+    const cachedDailyCat = readDailyCatCache();
+    if (cachedDailyCat?.date === getTodayDate()) {
+      dispatch({ type: GET_RANDOM_IMAGE, payload: [cachedDailyCat.cat] });
+      dispatch(asyncActionFinish());
+      return;
+    }
+
     try {
       const response = await fetch(baseUrl + 'images/search', { headers });
       if (response.ok) {
         const data = await response.json();
+        if (data[0]) {
+          writeDailyCatCache(data[0]);
+        }
         dispatch({ type: GET_RANDOM_IMAGE, payload: data });
       }
       dispatch(asyncActionFinish());


### PR DESCRIPTION
## Summary
- rename `getRandomImage` to `getDailyCat`
- cache the daily cat in `localStorage` using `cats-guide:daily-cat`
- reuse the cached cat on the same local date
- gracefully fall back to the API if storage is unavailable or corrupted

## Validation
- same-day reload uses cached cat without a new API call
- next-day visit fetches a new cat and updates the cache
- app still builds successfully