### PR TITLE
feat(quiz): implement Quiz game - Adivina la Raza (#15)

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -10,6 +10,7 @@ import PageNotFound from './PageNotFound/PageNotFound';
 import ModalManager from './common/modals/ModalManager';
 import GameHub from './Games/GameHub';
 import DifficultySelector from './Games/DifficultySelector';
+import QuizGame from './Games/Quiz/QuizGame';
 const App = () => {
   return (
     <div className='App'>
@@ -25,7 +26,8 @@ const App = () => {
           <Route path='404' element={<PageNotFound />} />
           <Route path='juegos' element={<GameHub />} />
           <Route path='juegos/:game' element={<DifficultySelector />} />
-          <Route path='juegos/:game/:difficulty' element={<PageNotFound />} />
+          <Route path='juegos/quiz/:difficulty' element={<QuizGame />} />
+          <Route path='juegos/memory/:difficulty' element={<PageNotFound />} />
         </Routes>
       </main>
       <footer>

--- a/src/app/Games/Quiz/ExitModal.jsx
+++ b/src/app/Games/Quiz/ExitModal.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+const ExitModal = ({ onConfirm, onCancel }) => (
+  <div
+    className="fixed inset-0 z-50 flex items-center justify-center px-4"
+    style={{ backgroundColor: 'rgba(0,0,0,0.75)', backdropFilter: 'blur(4px)' }}
+  >
+    <div className="bg-surface border border-border rounded-2xl p-6 max-w-xs w-full flex flex-col gap-5 text-center">
+      <div>
+        <p className="font-heading text-base font-bold text-foreground mb-1">
+          ¿Abandonar la partida?
+        </p>
+        <p className="font-body text-sm text-muted">El progreso no se guardará.</p>
+      </div>
+      <div className="flex flex-col gap-2">
+        <button
+          onClick={onConfirm}
+          className="w-full font-heading text-sm font-bold py-3 rounded-xl cursor-pointer border-0 transition-opacity hover:opacity-90"
+          style={{ backgroundColor: '#FF6B6B', color: '#fff' }}
+        >
+          Abandonar
+        </button>
+        <button
+          onClick={onCancel}
+          className="w-full font-body text-sm py-3 rounded-xl cursor-pointer transition-colors"
+          style={{ backgroundColor: '#1A1A24', border: '1px solid #2E2E3E', color: '#8B8B9E' }}
+        >
+          Seguir jugando
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+export default ExitModal;

--- a/src/app/Games/Quiz/QuizGame.jsx
+++ b/src/app/Games/Quiz/QuizGame.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import useQuizStore from './useQuizStore';
+import QuizQuestion from './QuizQuestion';
+import QuizResult from './QuizResult';
+import ExitModal from './ExitModal';
+
+const QuizGame = () => {
+  const { difficulty } = useParams();
+  const navigate = useNavigate();
+  const [showExitModal, setShowExitModal] = useState(false);
+
+  const {
+    phase, questions, currentIndex, score, maxStreak,
+    selectedAnswer, isCorrect, timeLeft, timerActive,
+    startGame, selectAnswer, nextQuestion, resetGame, tickTimer,
+  } = useQuizStore();
+
+  useEffect(() => {
+    startGame(difficulty);
+    return () => resetGame();
+  }, [difficulty]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Timer tick
+  useEffect(() => {
+    if (!timerActive) return;
+    const id = setInterval(tickTimer, 1000);
+    return () => clearInterval(id);
+  }, [timerActive, tickTimer]);
+
+  // Block browser back button (React Router v6.0 — no useBlocker available)
+  useEffect(() => {
+    window.history.pushState(null, '', window.location.href);
+    const handler = () => {
+      window.history.pushState(null, '', window.location.href);
+      setShowExitModal(true);
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  if (phase === 'idle' || phase === 'loading') {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <p className="font-body text-sm text-muted animate-pulse">Cargando preguntas...</p>
+      </div>
+    );
+  }
+
+  if (phase === 'result') {
+    return (
+      <QuizResult
+        score={score}
+        total={questions.length}
+        maxStreak={maxStreak}
+        difficulty={difficulty}
+        onReplay={() => startGame(difficulty)}
+        onChangeLevel={() => navigate('/App/juegos/quiz')}
+        onHome={() => navigate('/App/juegos')}
+      />
+    );
+  }
+
+  const question = questions[currentIndex];
+  const showScore = difficulty !== 'pacifico';
+  const showTimer = difficulty === 'dificil';
+  const showFunFact = difficulty !== 'dificil';
+
+  return (
+    <div className="min-h-screen bg-background">
+      {showExitModal && (
+        <ExitModal
+          onConfirm={() => navigate('/App/juegos')}
+          onCancel={() => setShowExitModal(false)}
+        />
+      )}
+
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <button
+          onClick={() => setShowExitModal(true)}
+          className="font-body text-sm text-muted hover:text-foreground transition-colors bg-transparent border-0 cursor-pointer p-0"
+        >
+          ✕
+        </button>
+        <span className="font-body text-sm text-muted">
+          {currentIndex + 1}/{questions.length}
+        </span>
+        {showScore ? (
+          <span className="font-heading text-sm font-bold text-amber">{score} pts</span>
+        ) : (
+          <span className="w-10" />
+        )}
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full h-1 bg-border">
+        <div
+          className="h-full bg-amber transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / questions.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Timer */}
+      {showTimer && phase === 'playing' && (
+        <div className="flex justify-center pt-3">
+          <span
+            className="font-heading text-2xl font-bold"
+            style={{ color: timeLeft <= 10 ? '#FF6B6B' : '#F59E0B' }}
+          >
+            {timeLeft}s
+          </span>
+        </div>
+      )}
+
+      <QuizQuestion
+        question={question}
+        selectedAnswer={selectedAnswer}
+        isCorrect={isCorrect}
+        phase={phase}
+        showFunFact={showFunFact}
+        onSelect={selectAnswer}
+        onNext={nextQuestion}
+      />
+    </div>
+  );
+};
+
+export default QuizGame;

--- a/src/app/Games/Quiz/QuizQuestion.jsx
+++ b/src/app/Games/Quiz/QuizQuestion.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+const STYLES = {
+  correct: { bg: '#34D39915', border: '#34D399', color: '#34D399' },
+  wrong:   { bg: '#FF6B6B15', border: '#FF6B6B', color: '#FF6B6B' },
+  default: { bg: '#1A1A24',   border: '#2E2E3E', color: '#F2F2F7' },
+};
+
+function getStyle(option, correctAnswer, selectedAnswer, answered) {
+  if (!answered) return STYLES.default;
+  if (option === correctAnswer) return STYLES.correct;
+  if (option === selectedAnswer) return STYLES.wrong;
+  return STYLES.default;
+}
+
+const QuizQuestion = ({ question, selectedAnswer, isCorrect, phase, showFunFact, onSelect, onNext }) => {
+  const answered = phase === 'feedback';
+
+  return (
+    <div className="max-w-md mx-auto px-4 pt-4 pb-8 flex flex-col gap-4">
+      <div
+        className="w-full rounded-2xl overflow-hidden border border-border"
+        style={{ aspectRatio: '4/3' }}
+      >
+        <img
+          src={question.imageUrl}
+          alt="¿De qué raza es este gato?"
+          className="w-full h-full object-cover"
+        />
+      </div>
+
+      <p className="font-heading text-lg font-bold text-foreground text-center">
+        ¿De qué raza es este gato?
+      </p>
+
+      <div className="flex flex-col gap-2">
+        {question.options.map((option) => {
+          const s = getStyle(option, question.correctAnswer, selectedAnswer, answered);
+          return (
+            <button
+              key={option}
+              disabled={answered}
+              onClick={() => onSelect(option)}
+              className="w-full font-body text-sm font-semibold rounded-xl border transition-colors text-left px-4 cursor-pointer disabled:cursor-default"
+              style={{ minHeight: 52, backgroundColor: s.bg, borderColor: s.border, color: s.color }}
+            >
+              {option}
+            </button>
+          );
+        })}
+      </div>
+
+      {answered && (
+        <>
+          <p
+            className="font-heading text-base font-bold text-center"
+            style={{ color: isCorrect ? '#34D399' : '#FF6B6B' }}
+          >
+            {isCorrect ? '¡Correcto!' : `Era: ${question.correctAnswer}`}
+          </p>
+
+          {showFunFact && question.funFact && (
+            <div className="bg-surface border border-border rounded-2xl p-4">
+              <p className="font-body text-xs text-muted leading-relaxed">{question.funFact}</p>
+            </div>
+          )}
+
+          <button
+            onClick={onNext}
+            className="w-full font-heading text-sm font-bold py-3 rounded-xl border-0 cursor-pointer transition-opacity hover:opacity-90"
+            style={{ backgroundColor: '#F59E0B', color: '#0F0F14' }}
+          >
+            Siguiente →
+          </button>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default QuizQuestion;

--- a/src/app/Games/Quiz/QuizResult.jsx
+++ b/src/app/Games/Quiz/QuizResult.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect } from 'react';
+
+const MESSAGES = [
+  { min: 9, text: 'Experto felino. Impresionante.' },
+  { min: 7, text: 'Muy bien jugado.' },
+  { min: 5, text: 'Buen intento.' },
+  { min: 3, text: 'Vas aprendiendo.' },
+  { min: 0, text: 'Los gatos te perdonan. Por ahora.' },
+];
+
+function saveStats(score, maxStreak, difficulty) {
+  try {
+    const raw = localStorage.getItem('cg_quiz_stats');
+    const prev = raw ? JSON.parse(raw) : {};
+    localStorage.setItem(
+      'cg_quiz_stats',
+      JSON.stringify({
+        bestScore: Math.max(prev.bestScore ?? 0, score),
+        bestStreak: Math.max(prev.bestStreak ?? 0, maxStreak),
+        gamesPlayed: (prev.gamesPlayed ?? 0) + 1,
+        lastDifficulty: difficulty,
+      })
+    );
+  } catch {
+    // noop
+  }
+}
+
+const QuizResult = ({ score, total, maxStreak, difficulty, onReplay, onChangeLevel, onHome }) => {
+  useEffect(() => {
+    saveStats(score, maxStreak, difficulty);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const message = MESSAGES.find((m) => score >= m.min)?.text ?? MESSAGES.at(-1).text;
+  const pct = Math.round((score / total) * 100);
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
+      <div className="max-w-sm w-full text-center flex flex-col gap-6">
+        <div>
+          <p className="font-heading text-7xl font-bold text-amber mb-2">
+            {score}/{total}
+          </p>
+          <p className="font-body text-base text-muted">{message}</p>
+        </div>
+
+        <div className="bg-surface border border-border rounded-2xl p-4 grid grid-cols-3 gap-4">
+          <div>
+            <p className="font-heading text-xl font-bold text-foreground">{score}</p>
+            <p className="font-body text-xs text-muted">Score</p>
+          </div>
+          <div>
+            <p className="font-heading text-xl font-bold text-foreground">{pct}%</p>
+            <p className="font-body text-xs text-muted">Precisión</p>
+          </div>
+          <div>
+            <p className="font-heading text-xl font-bold text-foreground">{maxStreak}</p>
+            <p className="font-body text-xs text-muted">Racha máx.</p>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={onReplay}
+            className="w-full font-heading text-sm font-bold py-3 rounded-xl border-0 cursor-pointer transition-opacity hover:opacity-90"
+            style={{ backgroundColor: '#F59E0B', color: '#0F0F14' }}
+          >
+            Jugar de nuevo
+          </button>
+          <button
+            onClick={onChangeLevel}
+            className="w-full font-heading text-sm font-bold py-3 rounded-xl cursor-pointer transition-colors"
+            style={{ backgroundColor: '#1A1A24', border: '1px solid #2E2E3E', color: '#F2F2F7' }}
+          >
+            Cambiar nivel
+          </button>
+          <button
+            onClick={onHome}
+            className="font-body text-sm text-muted hover:text-foreground transition-colors bg-transparent border-0 cursor-pointer"
+          >
+            Ir al inicio
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuizResult;

--- a/src/app/Games/Quiz/quizService.js
+++ b/src/app/Games/Quiz/quizService.js
@@ -1,0 +1,45 @@
+const BASE_URL = 'https://api.thecatapi.com/v1/';
+const HEADERS = { 'x-api-key': 'c2db22b7-52b8-4f16-82db-c0cbb4d39136' };
+
+function shuffle(arr) {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+export async function buildQuizQuestions() {
+  const [imagesRes, breedsRes] = await Promise.all([
+    fetch(`${BASE_URL}images/search?limit=50&has_breeds=1`, { headers: HEADERS }),
+    fetch(`${BASE_URL}breeds`, { headers: HEADERS }),
+  ]);
+
+  const images = await imagesRes.json();
+  const allBreeds = await breedsRes.json();
+  const allBreedNames = allBreeds.map((b) => b.name);
+
+  const seen = new Set();
+  const unique = [];
+  for (const img of images) {
+    if (!img.breeds?.length) continue;
+    const breedId = img.breeds[0].id;
+    if (!seen.has(breedId)) {
+      seen.add(breedId);
+      unique.push(img);
+    }
+    if (unique.length === 10) break;
+  }
+
+  return unique.map((img) => {
+    const correctAnswer = img.breeds[0].name;
+    const wrongOptions = shuffle(allBreedNames.filter((n) => n !== correctAnswer)).slice(0, 3);
+    return {
+      imageUrl: img.url,
+      correctAnswer,
+      funFact: img.breeds[0].description || null,
+      options: shuffle([correctAnswer, ...wrongOptions]),
+    };
+  });
+}

--- a/src/app/Games/Quiz/useQuizStore.js
+++ b/src/app/Games/Quiz/useQuizStore.js
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+import { buildQuizQuestions } from './quizService';
+
+const INITIAL = {
+  questions: [],
+  currentIndex: 0,
+  score: 0,
+  streak: 0,
+  maxStreak: 0,
+  selectedAnswer: null,
+  isCorrect: null,
+  timeLeft: 60,
+  timerActive: false,
+  phase: 'idle', // idle | loading | playing | feedback | result
+  difficulty: null,
+};
+
+const useQuizStore = create((set, get) => ({
+  ...INITIAL,
+
+  startGame: async (difficulty) => {
+    set({ ...INITIAL, phase: 'loading', difficulty });
+    try {
+      const questions = await buildQuizQuestions();
+      set({ questions, phase: 'playing', timerActive: difficulty === 'dificil', timeLeft: 60 });
+    } catch {
+      set({ phase: 'idle' });
+    }
+  },
+
+  selectAnswer: (answer) => {
+    const { questions, currentIndex, score, streak, maxStreak } = get();
+    const correct = questions[currentIndex].correctAnswer;
+    const isCorrect = answer === correct;
+    const newStreak = isCorrect ? streak + 1 : 0;
+    set({
+      selectedAnswer: answer,
+      isCorrect,
+      score: isCorrect ? score + 1 : score,
+      streak: newStreak,
+      maxStreak: Math.max(maxStreak, newStreak),
+      phase: 'feedback',
+      timerActive: false,
+    });
+  },
+
+  nextQuestion: () => {
+    const { currentIndex, questions, difficulty } = get();
+    if (currentIndex >= questions.length - 1) {
+      set({ phase: 'result' });
+    } else {
+      set({
+        currentIndex: currentIndex + 1,
+        selectedAnswer: null,
+        isCorrect: null,
+        phase: 'playing',
+        timerActive: difficulty === 'dificil',
+        timeLeft: 60,
+      });
+    }
+  },
+
+  tickTimer: () => {
+    const { timeLeft, timerActive, phase } = get();
+    if (!timerActive || phase !== 'playing') return;
+    if (timeLeft <= 1) {
+      get().selectAnswer('__timeout__');
+    } else {
+      set({ timeLeft: timeLeft - 1 });
+    }
+  },
+
+  resetGame: () => set(INITIAL),
+}));
+
+export default useQuizStore;


### PR DESCRIPTION
## Summary
- Zustand store (`useQuizStore`) maneja questions, score, streak y timer
- `quizService` fetches 50 imágenes con razas + lista completa de razas para armar 10 preguntas únicas
- `QuizGame`: header con progreso/score, progress bar ámbar, timer para Difícil
- `QuizQuestion`: imagen 4:3, 4 opciones con feedback verde/rojo, dato curioso (Pacífico y Fácil)
- `QuizResult`: score, precisión, racha máx — guarda en `cg_quiz_stats` en localStorage
- `ExitModal`: confirmación antes de abandonar (partida no se guarda)
- Back button bloqueado via `popstate` (workaround para React Router 6.0 sin `useBlocker`)

## Niveles
| Nivel | Timer | Score visible | Dato curioso |
|-------|-------|--------------|--------------|
| Pacífico | No | No | Sí |
| Fácil | No | Sí | Sí |
| Difícil | 60s total | Sí | No |

## Test plan
- [ ] Navegar Landing → Juegos → Quiz → elegir dificultad → jugar
- [ ] Responder correcta: opción se pone verde, aparece dato curioso (Pacífico/Fácil)
- [ ] Responder incorrecta: opción roja, se resalta la correcta en verde
- [ ] Difícil: timer cuenta regresiva, se pausa en feedback, se reanuda al presionar Siguiente
- [ ] Difícil: tiempo agotado → respuesta incorrecta automática
- [ ] Completar 10 preguntas → pantalla de resultado con score/precisión/racha
- [ ] "Jugar de nuevo" → nueva partida misma dificultad
- [ ] "Cambiar nivel" → vuelve al selector
- [ ] "Ir al inicio" → vuelve al hub
- [ ] Stats guardadas en localStorage, visibles en GameHub
- [ ] ✕ abre modal de confirmación; "Seguir jugando" cierra el modal
- [ ] Back button físico (Android) → abre modal de confirmación
- [ ] Validar mobile 375px

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)